### PR TITLE
Exclude unneeded output files from data_transfer

### DIFF
--- a/scripts/data_transfer.pl
+++ b/scripts/data_transfer.pl
@@ -54,14 +54,8 @@ else {
 }
 
 my @files_xfer = qw(
-    ampinfo.txt 
-    ampcounts.txt 
     cram 
     cram.crai
-    haplotectloci.txt 
-    haplotect.txt 
-    cleaned.vcf.gz
-    combined_and_tagged.vcf 
     annotated.vcf.gz
     annotated_filtered.vcf.gz
     report.txt


### PR DESCRIPTION
Exclude amp (too big, not useful), haplotect (already included in report.txt) and two intermediate vcf files from transfer.