### PR TITLE
Update json with the correct repo path and new dragen-2 queue

### DIFF
--- a/MyeloseqHD.json
+++ b/MyeloseqHD.json
@@ -9,9 +9,10 @@
     "MyeloseqHD.MinReads":5,
     "MyeloseqHD.MinVaf":0.02,
     "MyeloseqHD.VariantDB":"/storage1/fs1/gtac-mgi/Active/CLE/validation/cle_validation/CLE_variant_database/myeloseqhd/myeloseqhd_variants.sqlite",
-    "MyeloseqHD.MyeloSeqHDRepo":"/storage1/fs1/dspencer/Active/spencerlab/dhs/git/cle-myeloseqhd-2",
-    "MyeloseqHD.DragenDockerImage":"docker1(seqfu/centos7-dragen-4.0.3:latest)",
-    "MyeloseqHD.DragenQueue":"duncavagee",
+    "MyeloseqHD.MyeloSeqHDRepo":"/storage1/fs1/duncavagee/Active/SEQ/MyeloSeqHD/process/git/cle-myeloseqhd",
+    "MyeloseqHD.DragenEnv":"LSF_DOCKER_DRAGEN=y",
+    "MyeloseqHD.DragenDockerImage":"gtac-mgi-dragen(seqfu/oracle8-dragen-4.0.3:latest)",
+    "MyeloseqHD.DragenQueue":"dragen-2",
     "MyeloseqHD.Queue":"dspencer",
     "MyeloseqHD.JobGroup":"/cle/wdl/haloplex"
 }

--- a/MyeloseqHDAnalysis.json
+++ b/MyeloseqHDAnalysis.json
@@ -16,7 +16,7 @@
     "MyeloseqHDAnalysis.refFasta":"/storage1/fs1/duncavagee/Active/SEQ/Chromoseq/process/refdata/hg38/all_sequences.fa",
     "MyeloseqHDAnalysis.ReferenceDict":"/storage1/fs1/duncavagee/Active/SEQ/Chromoseq/process/refdata/hg38/all_sequences.dict",
     "MyeloseqHDAnalysis.Vepcache":"/storage1/fs1/gtac-mgi/Active/CLE/reference/VEP_cache", 
-    "MyeloseqHDAnalysis.MyeloSeqHDRepo":"/storage1/fs1/dspencer/Active/spencerlab/dhs/git/cle-myeloseqhd-2",
+    "MyeloseqHDAnalysis.MyeloSeqHDRepo":"/storage1/fs1/duncavagee/Active/SEQ/MyeloSeqHD/process/git/cle-myeloseqhd",
     "MyeloseqHDAnalysis.VariantDB":"/storage1/fs1/gtac-mgi/Active/CLE/validation/cle_validation/CLE_variant_database/myeloseqhd/myeloseqhd_variants.sqlite",
     "MyeloseqHDAnalysis.MinReads":5,
     "MyeloseqHDAnalysis.MinVaf":0.02,

--- a/MyeloseqHD_alt.json
+++ b/MyeloseqHD_alt.json
@@ -9,7 +9,7 @@
     "MyeloseqHD.MinReads":5,
     "MyeloseqHD.MinVaf":0.02,
     "MyeloseqHD.VariantDB":"/storage1/fs1/gtac-mgi/Active/CLE/validation/cle_validation/CLE_variant_database/myeloseqhd/myeloseqhd_variants.sqlite",
-    "MyeloseqHD.MyeloSeqHDRepo":"/storage1/fs1/dspencer/Active/spencerlab/dhs/git/cle-myeloseqhd-2",
+    "MyeloseqHD.MyeloSeqHDRepo":"/storage1/fs1/duncavagee/Active/SEQ/MyeloSeqHD/process/git/cle-myeloseqhd",
     "MyeloseqHD.DragenEnv":"LSF_DOCKER_DRAGEN=y",
     "MyeloseqHD.DragenDockerImage":"gtac-mgi-dragen(seqfu/oracle8-dragen-4.0.3:latest)",
     "MyeloseqHD.DragenQueue":"dragen",


### PR DESCRIPTION
1. Use MSHD production SEQ/process repo path
2. Update with the upcoming upgraded dragen-2 queue (replacing duncavagee queue)